### PR TITLE
feat: add functionality to unregister aggregate

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -182,6 +182,18 @@ func RegisterAggregate(factory func(uuid.UUID) Aggregate) {
 	aggregates[aggregateType] = factory
 }
 
+// RegisterAggregate un-registers an aggregate by a given type.
+func UnregisterAggregate(aggregateType AggregateType) {
+	aggregatesMu.Lock()
+	defer aggregatesMu.Unlock()
+
+	if _, ok := aggregates[aggregateType]; !ok {
+		panic(fmt.Sprintf("eventhorizon: aggregate of type %q was never registered", aggregateType))
+	}
+
+	delete(aggregates, aggregateType)
+}
+
 // CreateAggregate creates an aggregate of a type with an ID using the factory
 // registered with RegisterAggregate.
 func CreateAggregate(aggregateType AggregateType, id uuid.UUID) (Aggregate, error) {

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -82,10 +82,21 @@ func TestRegisterAggregateTwice(t *testing.T) {
 	})
 }
 
+func TestUnregisterAggregateUnregistered(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil || r != "eventhorizon: aggregate of type \"TestAggregateUnregistered\" was never registered" {
+			t.Error("there should have been a panic:", r)
+		}
+	}()
+
+	UnregisterAggregate(TestAggregateUnregisteredType)
+}
+
 const (
 	TestAggregateRegisterType      AggregateType = "TestAggregateRegister"
 	TestAggregateRegisterEmptyType AggregateType = ""
 	TestAggregateRegisterTwiceType AggregateType = "TestAggregateRegisterTwice"
+	TestAggregateUnregisteredType  AggregateType = "TestAggregateUnregistered"
 )
 
 type TestAggregateRegister struct {


### PR DESCRIPTION
- adds functionality to unregister an previously registered aggregate (usefull for testing)
- adds tests
