### PR TITLE
Extend eventstore maintenance

### DIFF
--- a/eventmaintenance.go
+++ b/eventmaintenance.go
@@ -16,6 +16,8 @@ package eventhorizon
 
 import (
 	"context"
+
+	"github.com/Clarilab/eventhorizon/uuid"
 )
 
 // EventStoreMaintenance is an interface with maintenance tools for an EventStore.
@@ -27,6 +29,9 @@ type EventStoreMaintenance interface {
 
 	// RenameEvent renames all instances of the event type.
 	RenameEvent(ctx context.Context, from, to EventType) error
+
+	// Remove removes all events for a given aggregate.
+	Remove(ctx context.Context, aggregateID uuid.UUID) error
 
 	// Clear clears the event storage.
 	Clear(ctx context.Context) error

--- a/eventstore.go
+++ b/eventstore.go
@@ -71,6 +71,8 @@ const (
 	EventStoreOpReplace = "replace"
 	// Errors during renaming of event types.
 	EventStoreOpRename = "rename"
+	// Errors during removing of events.
+	EventStoreOpRemove = "remove"
 	// Errors during clearing of the event store.
 	EventStoreOpClear = "clear"
 

--- a/eventstore/memory/eventmaintenance.go
+++ b/eventstore/memory/eventmaintenance.go
@@ -120,6 +120,16 @@ func (s *EventStore) RenameEvent(ctx context.Context, from, to eh.EventType) err
 	return nil
 }
 
+// Remove implements the Remove method of the eventhorizon.EventStoreMaintenance interface.
+func (s *EventStore) Remove(ctx context.Context, id uuid.UUID) error {
+	s.dbMu.Lock()
+	defer s.dbMu.Unlock()
+
+	delete(s.db, id)
+
+	return nil
+}
+
 // Clear implements the Clear method of the eventhorizon.EventStoreMaintenance interface.
 func (s *EventStore) Clear(ctx context.Context) error {
 	s.dbMu.Lock()

--- a/eventstore/mongodb_v2/eventstore.go
+++ b/eventstore/mongodb_v2/eventstore.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -468,121 +467,6 @@ func (s *EventStore) loadFromCursor(ctx context.Context, id uuid.UUID, cursor *m
 	}
 
 	return events, nil
-}
-
-func (s *EventStore) LoadSnapshot(ctx context.Context, id uuid.UUID) (*eh.Snapshot, error) {
-	const errMessage = "could not load snapshot: %w"
-
-	var (
-		record   = new(SnapshotRecord)
-		snapshot = new(eh.Snapshot)
-		err      error
-	)
-
-	if err = s.database.CollectionExec(ctx, s.snapshotsCollectionName, func(ctx context.Context, c *mongo.Collection) error {
-		err = c.FindOne(ctx, bson.M{"aggregate_id": id}, mongoOptions.FindOne().SetSort(bson.M{"version": -1})).Decode(record)
-		if err != nil {
-			if errors.Is(err, mongo.ErrNoDocuments) {
-				return nil
-			}
-
-			return &eh.EventStoreError{
-				Err:         fmt.Errorf("could not decode snapshot: %w", err),
-				Op:          eh.EventStoreOpLoadSnapshot,
-				AggregateID: id,
-			}
-		}
-
-		return nil
-	}); err != nil {
-		return nil, fmt.Errorf(errMessage, err)
-	}
-
-	if snapshot.State, err = eh.CreateSnapshotData(record.AggregateID, record.AggregateType); err != nil {
-		return nil, &eh.EventStoreError{
-			Err:         fmt.Errorf("could not decode snapshot: %w", err),
-			Op:          eh.EventStoreOpLoadSnapshot,
-			AggregateID: id,
-		}
-	}
-
-	if err = record.decompress(); err != nil {
-		return nil, &eh.EventStoreError{
-			Err:         fmt.Errorf("could not decompress snapshot: %w", err),
-			Op:          eh.EventStoreOpLoadSnapshot,
-			AggregateID: id,
-		}
-	}
-
-	if err = json.Unmarshal(record.RawData, snapshot); err != nil {
-		return nil, &eh.EventStoreError{
-			Err:         fmt.Errorf("could not decode snapshot: %w", err),
-			Op:          eh.EventStoreOpLoadSnapshot,
-			AggregateID: id,
-		}
-	}
-
-	return snapshot, nil
-}
-
-func (s *EventStore) SaveSnapshot(ctx context.Context, id uuid.UUID, snapshot eh.Snapshot) (err error) {
-	const errMessage = "could not save snapshot: %w"
-
-	if snapshot.AggregateType == "" {
-		return &eh.EventStoreError{
-			Err:           fmt.Errorf("aggregate type is empty"),
-			Op:            eh.EventStoreOpSaveSnapshot,
-			AggregateID:   id,
-			AggregateType: snapshot.AggregateType,
-		}
-	}
-
-	if snapshot.State == nil {
-		return &eh.EventStoreError{
-			Err:           fmt.Errorf("snapshots state is nil"),
-			Op:            eh.EventStoreOpSaveSnapshot,
-			AggregateID:   id,
-			AggregateType: snapshot.AggregateType,
-		}
-	}
-
-	record := SnapshotRecord{
-		AggregateID:   id,
-		AggregateType: snapshot.AggregateType,
-		Timestamp:     time.Now(),
-		Version:       snapshot.Version,
-	}
-
-	if record.RawData, err = json.Marshal(snapshot); err != nil {
-		return
-	}
-
-	if err = record.compress(); err != nil {
-		return &eh.EventStoreError{
-			Err:         fmt.Errorf("could not compress snapshot: %w", err),
-			Op:          eh.EventStoreOpSaveSnapshot,
-			AggregateID: id,
-		}
-	}
-
-	if err = s.database.CollectionExec(ctx, s.snapshotsCollectionName, func(ctx context.Context, c *mongo.Collection) error {
-		if _, err := c.InsertOne(ctx,
-			record,
-			mongoOptions.InsertOne(),
-		); err != nil {
-			return &eh.EventStoreError{
-				Err:         fmt.Errorf("could not save snapshot: %w", err),
-				Op:          eh.EventStoreOpSaveSnapshot,
-				AggregateID: id,
-			}
-		}
-
-		return nil
-	}); err != nil {
-		return fmt.Errorf(errMessage, err)
-	}
-
-	return nil
 }
 
 // Close implements the Close method of the eventhorizon.EventStore interface.

--- a/eventstore/mongodb_v2/snapshot.go
+++ b/eventstore/mongodb_v2/snapshot.go
@@ -1,0 +1,130 @@
+package mongodb_v2
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	eh "github.com/Clarilab/eventhorizon"
+	"github.com/Clarilab/eventhorizon/uuid"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	mongoOptions "go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func (s *EventStore) LoadSnapshot(ctx context.Context, id uuid.UUID) (*eh.Snapshot, error) {
+	const errMessage = "could not load snapshot: %w"
+
+	var (
+		record   = new(SnapshotRecord)
+		snapshot = new(eh.Snapshot)
+		err      error
+	)
+
+	if err = s.database.CollectionExec(ctx, s.snapshotsCollectionName, func(ctx context.Context, c *mongo.Collection) error {
+		err = c.FindOne(ctx, bson.M{"aggregate_id": id}, mongoOptions.FindOne().SetSort(bson.M{"version": -1})).Decode(record)
+		if err != nil {
+			if errors.Is(err, mongo.ErrNoDocuments) {
+				return nil
+			}
+
+			return &eh.EventStoreError{
+				Err:         fmt.Errorf("could not decode snapshot: %w", err),
+				Op:          eh.EventStoreOpLoadSnapshot,
+				AggregateID: id,
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf(errMessage, err)
+	}
+
+	if snapshot.State, err = eh.CreateSnapshotData(record.AggregateID, record.AggregateType); err != nil {
+		return nil, &eh.EventStoreError{
+			Err:         fmt.Errorf("could not decode snapshot: %w", err),
+			Op:          eh.EventStoreOpLoadSnapshot,
+			AggregateID: id,
+		}
+	}
+
+	if err = record.decompress(); err != nil {
+		return nil, &eh.EventStoreError{
+			Err:         fmt.Errorf("could not decompress snapshot: %w", err),
+			Op:          eh.EventStoreOpLoadSnapshot,
+			AggregateID: id,
+		}
+	}
+
+	if err = json.Unmarshal(record.RawData, snapshot); err != nil {
+		return nil, &eh.EventStoreError{
+			Err:         fmt.Errorf("could not decode snapshot: %w", err),
+			Op:          eh.EventStoreOpLoadSnapshot,
+			AggregateID: id,
+		}
+	}
+
+	return snapshot, nil
+}
+
+func (s *EventStore) SaveSnapshot(ctx context.Context, id uuid.UUID, snapshot eh.Snapshot) (err error) {
+	const errMessage = "could not save snapshot: %w"
+
+	if snapshot.AggregateType == "" {
+		return &eh.EventStoreError{
+			Err:           fmt.Errorf("aggregate type is empty"),
+			Op:            eh.EventStoreOpSaveSnapshot,
+			AggregateID:   id,
+			AggregateType: snapshot.AggregateType,
+		}
+	}
+
+	if snapshot.State == nil {
+		return &eh.EventStoreError{
+			Err:           fmt.Errorf("snapshots state is nil"),
+			Op:            eh.EventStoreOpSaveSnapshot,
+			AggregateID:   id,
+			AggregateType: snapshot.AggregateType,
+		}
+	}
+
+	record := SnapshotRecord{
+		AggregateID:   id,
+		AggregateType: snapshot.AggregateType,
+		Timestamp:     time.Now(),
+		Version:       snapshot.Version,
+	}
+
+	if record.RawData, err = json.Marshal(snapshot); err != nil {
+		return
+	}
+
+	if err = record.compress(); err != nil {
+		return &eh.EventStoreError{
+			Err:         fmt.Errorf("could not compress snapshot: %w", err),
+			Op:          eh.EventStoreOpSaveSnapshot,
+			AggregateID: id,
+		}
+	}
+
+	if err = s.database.CollectionExec(ctx, s.snapshotsCollectionName, func(ctx context.Context, c *mongo.Collection) error {
+		if _, err := c.InsertOne(ctx,
+			record,
+			mongoOptions.InsertOne(),
+		); err != nil {
+			return &eh.EventStoreError{
+				Err:         fmt.Errorf("could not save snapshot: %w", err),
+				Op:          eh.EventStoreOpSaveSnapshot,
+				AggregateID: id,
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf(errMessage, err)
+	}
+
+	return nil
+}

--- a/eventstore/mongodb_v2/snapshot_test.go
+++ b/eventstore/mongodb_v2/snapshot_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 - The Event Horizon authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodb_v2_test
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"testing"
+
+	"github.com/Clarilab/eventhorizon/eventstore"
+	mongodb "github.com/Clarilab/eventhorizon/eventstore/mongodb_v2"
+)
+
+func TestEventStoreSnapshotStoreIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Use MongoDB in Docker with fallback to localhost.
+	addr := os.Getenv("MONGODB_ADDR")
+	if addr == "" {
+		addr = "localhost:27017"
+	}
+
+	url := "mongodb://" + addr
+
+	// Get a random DB name.
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatal(err)
+	}
+
+	db := "test-" + hex.EncodeToString(b)
+
+	t.Log("using DB:", db)
+
+	store, err := mongodb.NewEventStore(url, db)
+	if err != nil {
+		t.Fatal("there should be no error:", err)
+	}
+
+	if store == nil {
+		t.Fatal("there should be a store")
+	}
+
+	defer store.Close()
+
+	eventstore.SnapshotAcceptanceTest(t, store, context.Background())
+}

--- a/namespace/eventmaintenance.go
+++ b/namespace/eventmaintenance.go
@@ -20,6 +20,7 @@ import (
 
 	// Register uuid.UUID as BSON type.
 	_ "github.com/Clarilab/eventhorizon/codec/bson"
+	"github.com/Clarilab/eventhorizon/uuid"
 
 	eh "github.com/Clarilab/eventhorizon"
 )
@@ -58,6 +59,24 @@ func (s *EventStore) RenameEvent(ctx context.Context, from, to eh.EventType) err
 	}
 
 	return maintenance.RenameEvent(ctx, from, to)
+}
+
+// Remove implements the Remove method of the eventhorizon.EventStoreMaintenance interface.
+func (s *EventStore) Remove(ctx context.Context, id uuid.UUID) error {
+	store, err := s.eventStore(ctx)
+	if err != nil {
+		return err
+	}
+
+	maintenance, ok := store.(eh.EventStoreMaintenance)
+	if !ok {
+		return &eh.EventStoreError{
+			Err: fmt.Errorf("event store does not support removing events storage"),
+			Op:  eh.EventStoreOpRemove,
+		}
+	}
+
+	return maintenance.Remove(ctx, id)
 }
 
 // Clear implements the Clear method of the eventhorizon.EventStoreMaintenance interface.

--- a/namespace/snapshots.go
+++ b/namespace/snapshots.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 - The Event Horizon authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace
+
+import (
+	"context"
+	"fmt"
+
+	// Register uuid.UUID as BSON type.
+	_ "github.com/Clarilab/eventhorizon/codec/bson"
+	"github.com/Clarilab/eventhorizon/uuid"
+
+	eh "github.com/Clarilab/eventhorizon"
+)
+
+// SaveSnapshot implements the Remove SaveSnapshot of the eventhorizon.SnapshotStore interface.
+func (s *EventStore) SaveSnapshot(ctx context.Context, id uuid.UUID, snapshot eh.Snapshot) (err error) {
+	store, err := s.eventStore(ctx)
+	if err != nil {
+		return err
+	}
+
+	snapshotStore, ok := store.(eh.SnapshotStore)
+	if !ok {
+		return &eh.EventStoreError{
+			Err: fmt.Errorf("event store does not support snapshots"),
+			Op:  eh.EventStoreOpReplace,
+		}
+	}
+
+	return snapshotStore.SaveSnapshot(ctx, id, snapshot)
+}
+
+// LoadSnapshot implements the Remove LoadSnapshot of the eventhorizon.SnapshotStore interface.
+func (s *EventStore) LoadSnapshot(ctx context.Context, id uuid.UUID) (*eh.Snapshot, error) {
+	store, err := s.eventStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshotStore, ok := store.(eh.SnapshotStore)
+	if !ok {
+		return nil, &eh.EventStoreError{
+			Err: fmt.Errorf("event store does not support snapshots"),
+			Op:  eh.EventStoreOpReplace,
+		}
+	}
+
+	return snapshotStore.LoadSnapshot(ctx, id)
+}

--- a/namespace/snapshots_test.go
+++ b/namespace/snapshots_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2021 - The Event Horizon authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace_test
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"testing"
+
+	eh "github.com/Clarilab/eventhorizon"
+	"github.com/Clarilab/eventhorizon/eventstore"
+	mongodb "github.com/Clarilab/eventhorizon/eventstore/mongodb_v2"
+	"github.com/Clarilab/eventhorizon/namespace"
+)
+
+func TestEventStoreSnapshotStoreIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Use MongoDB in Docker with fallback to localhost.
+	addr := os.Getenv("MONGODB_ADDR")
+	if addr == "" {
+		addr = "localhost:27017"
+	}
+
+	url := "mongodb://" + addr
+
+	// Get a random DB name.
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatal(err)
+	}
+
+	db := "test-" + hex.EncodeToString(b)
+
+	t.Log("using DB:", db)
+
+	store := namespace.NewEventStore(func(ns string) (eh.EventStore, error) {
+		return mongodb.NewEventStore(url, db,
+			mongodb.WithCollectionNames(ns+"_events", ns+"_streams"),
+			mongodb.WithCollectionNames(ns+"_events", ns+"_streams"),
+		)
+	})
+
+	if store == nil {
+		t.Fatal("there should be a store")
+	}
+
+	defer store.Close()
+
+	eventstore.SnapshotAcceptanceTest(t, store, context.Background())
+}


### PR DESCRIPTION
- adds remove functionality to evenstore maintenance
- upgrades the maintenance acceptance test
- makes namespace eventstore a snapshot store
- adds missing custom snapshots collection functionality to mongo_v2 eventstore
