### PR TITLE
chore[eventstore/mongodb]: fix invalid aggregation syntax

### DIFF
--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -299,7 +299,7 @@ func (s *EventStore) LoadFrom(ctx context.Context, id uuid.UUID, version int) ([
 				"input": "$events",
 				"as":    "events",
 				"cond": bson.M{
-					"version": bson.M{"$gte": version},
+					"$gte": []interface{}{"$$events.version", version},
 				},
 			},
 		},
@@ -318,7 +318,7 @@ func (s *EventStore) LoadUntil(ctx context.Context, id uuid.UUID, version int) (
 				"input": "$events",
 				"as":    "events",
 				"cond": bson.M{
-					"version": bson.M{"$lte": version},
+					"$lte": []interface{}{"$$events.version", version},
 				},
 			},
 		},

--- a/examples/guestlist/mongodb/mongodb_test.go
+++ b/examples/guestlist/mongodb/mongodb_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/Clarilab/eventhorizon/examples/guestlist/domains/guestlist"
 )
 
-func ExampleIntegration() {
+func Example() {
 	if testing.Short() {
 		// Skip test when not running integration, fake success by printing.
 		fmt.Println(`invitation: Athena - confirmed

--- a/examples/guestlist/outbox/outbox_test.go
+++ b/examples/guestlist/outbox/outbox_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/Clarilab/eventhorizon/examples/guestlist/domains/guestlist"
 )
 
-func ExampleIntegration() {
+func Example() {
 	if testing.Short() {
 		// Skip test when not running integration, fake success by printing.
 		fmt.Println(`invitation: Athena - confirmed


### PR DESCRIPTION
eventstore/mongodb:
- add fix for invalid mongodb aggregation syntax

examples/guestlist:
- fix invalid example function naming (causing tests to fail)